### PR TITLE
revert: global training performs worse, revert to per-file training

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ End-to-end ML lifecycle for sensor anomaly detection using the SKAB dataset, wit
 - `scripts/run_predict.sh` (placeholder)
 - `scripts/run_monitoring.sh` (placeholder)
 
+**Training Approach**
+Training is per-file: a separate Isolation Forest is fitted on the first 70% of each
+experiment file and evaluated on the remaining 30%. Global training (one model across
+all files) was evaluated but produced significantly lower F1 (0.355 vs 0.665). The
+root cause is that anomaly patterns in SKAB are context-specific per experiment — a
+global model loses the local calibration needed to detect them reliably. If global
+training is revisited, per-file feature normalisation before concatenation would be
+the next step to try.
+
 **Project Layout**
 - `src/anomaly_detection`: core package
 - `data/`: raw, processed, interim

--- a/src/anomaly_detection/models/train.py
+++ b/src/anomaly_detection/models/train.py
@@ -49,9 +49,6 @@ def train_baseline_on_dataset(
 
     per_file: dict[str, dict] = {}
     file_metrics = []
-
-    # train on each file, evaluate, and store the "last" Model
-    # tbd: clean global training
     model = None
 
     for p in files:
@@ -64,15 +61,14 @@ def train_baseline_on_dataset(
         train_engineered = build_engineered_features(train_df, feature_cols, rolling_window)
         test_engineered = build_engineered_features(test_df, feature_cols, rolling_window)
 
-        all_feature_cols = [c for c in train_engineered.columns 
+        all_feature_cols = [c for c in train_engineered.columns
                             if c not in {timestamp_col, label_col, *(metadata_cols or [])}]
-        
+
         x_train = build_feature_matrix(train_engineered, all_feature_cols)
         x_test = build_feature_matrix(test_engineered, all_feature_cols)
 
         contamination = cfg.contamination
         if contamination == "from_data":
-            # Use train anomaly rate to calibrate threshold
             rate = float(np.asarray(train_df[label_col]).mean())
             contamination = float(np.clip(rate, 1e-4, 0.5))
 
@@ -111,10 +107,8 @@ def train_baseline_on_dataset(
     metrics_path = artifacts_metrics_dir / "baseline_isolation_forest.json"
     metrics_path.write_text(json.dumps(metrics, indent=2), encoding="utf-8")
 
-    # Save last trained model (minimal approach)
-    if model is not None:
-        model_path = artifacts_models_dir / "isolation_forest.joblib"
-        joblib.dump(model, model_path)
+    model_path = artifacts_models_dir / "isolation_forest.joblib"
+    joblib.dump(model, model_path)
 
     return metrics
 


### PR DESCRIPTION
Global training was evaluated (one IsolationForest across all experiment files). Despite excluding anomaly-free.csv (different operating regime: ~90C vs ~68C) from the training pool, F1 dropped from 0.665 to 0.355. Root cause: anomaly patterns in SKAB are context-specific per experiment, so a global model loses the local calibration needed to detect them.

Added a note to README documenting this finding and what to try if global training is revisited (per-file feature normalisation before concatenation).